### PR TITLE
Add support for Shorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,17 +74,26 @@ print(f"Video: {video}")
 channel = supadata.youtube.channel(id="https://youtube.com/@RickAstleyVEVO") # can be url, channel id, handle
 print(f"Channel: {channel}")
 
-# Get a list of the channel video IDs
-channel_videos = supadata.youtube.channel.videos(id="RickAstleyVEVO") # can be url, channel id, or handle
-print(f"Channel Video IDs: {channel_videos}")
+# Get video IDs from a YouTube channel
+channel_videos = supadata.youtube.channel.videos(
+    id="RickAstleyVEVO",  # can be url, channel id, or handle
+    type="all",  # 'all', 'video', or 'short'
+    limit=50
+)
+print(f"Regular videos: {channel_videos.video_ids}")
+print(f"Shorts: {channel_videos.short_ids}")
 
 # Get Playlist metadata
 playlist = supadata.youtube.playlist(id="PLlaN88a7y2_plecYoJxvRFTLHVbIVAOoc") # can be url or playlist id
 print(f"Playlist: {playlist}")
 
-# Get a list of the playlist video IDs
-playlist_videos = supadata.youtube.playlist.videos(id="https://www.youtube.com/playlist?list=PLlaN88a7y2_plecYoJxvRFTLHVbIVAOoc") # can be url or playlist id
-print(f"Playlist Videos IDs: {playlist_videos}")
+# Get video IDs from a YouTube playlist
+playlist_videos = supadata.youtube.playlist.videos(
+    id="https://www.youtube.com/playlist?list=PLlaN88a7y2_plecYoJxvRFTLHVbIVAOoc",  # can be url or playlist id
+    limit=50
+)
+print(f"Regular videos: {playlist_videos.video_ids}")
+print(f"Shorts: {playlist_videos.short_ids}")
 ```
 
 ## Error Handling

--- a/supadata/types.py
+++ b/supadata/types.py
@@ -254,3 +254,22 @@ class YoutubePlaylist:
             self.last_updated = datetime.now()
         if self.channel is None:
             self.channel = YoutubeChannelBaseDict(id="", name="")
+
+
+@dataclass
+class VideoIds:
+    """Container for YouTube video IDs.
+    
+    Attributes:
+        video_ids: List of regular YouTube video IDs
+        short_ids: List of YouTube Shorts IDs
+    """
+    
+    video_ids: List[str] = None
+    short_ids: List[str] = None
+    
+    def __post_init__(self):
+        if self.video_ids is None:
+            self.video_ids = []
+        if self.short_ids is None:
+            self.short_ids = []

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -427,16 +427,50 @@ def test_youtube_channel_videos(client: Supadata, requests_mock) -> None:
         "videoIds": [
             "PQ2WjtaPfXU",
             "UIVADiGfwWc",
+        ],
+        "shortIds": [
+            "abc123",
+            "def456",
         ]
     }
 
     requests_mock.get(
-        f"{client.base_url}/youtube/channel/videos?id={channel_id}", json=mock_response
+        f"{client.base_url}/youtube/channel/videos?id={channel_id}&type=all", json=mock_response
     )
     channel_videos = client.youtube.channel.videos(channel_id)
-    assert isinstance(channel_videos, list)
-    assert len(channel_videos) == len(mock_response["videoIds"])
-    for i in channel_videos:
+    assert hasattr(channel_videos, "video_ids")
+    assert hasattr(channel_videos, "short_ids")
+    assert isinstance(channel_videos.video_ids, list)
+    assert isinstance(channel_videos.short_ids, list)
+    assert len(channel_videos.video_ids) == len(mock_response["videoIds"])
+    assert len(channel_videos.short_ids) == len(mock_response["shortIds"])
+    for i in channel_videos.video_ids:
+        assert i in mock_response["videoIds"]
+    for i in channel_videos.short_ids:
+        assert i in mock_response["shortIds"]
+
+
+def test_youtube_channel_videos_with_type(client: Supadata, requests_mock) -> None:
+    channel_id = "UCsBjURrPoezyLs9EqgamOA"
+    mock_response = {
+        "videoIds": [
+            "PQ2WjtaPfXU",
+            "UIVADiGfwWc",
+        ],
+        "shortIds": []
+    }
+
+    requests_mock.get(
+        f"{client.base_url}/youtube/channel/videos?id={channel_id}&type=video", json=mock_response
+    )
+    channel_videos = client.youtube.channel.videos(channel_id, type="video")
+    assert hasattr(channel_videos, "video_ids")
+    assert hasattr(channel_videos, "short_ids")
+    assert isinstance(channel_videos.video_ids, list)
+    assert isinstance(channel_videos.short_ids, list)
+    assert len(channel_videos.video_ids) == len(mock_response["videoIds"])
+    assert len(channel_videos.short_ids) == 0
+    for i in channel_videos.video_ids:
         assert i in mock_response["videoIds"]
 
 
@@ -448,7 +482,7 @@ def test_youtube_channel_videos_invalid_id(client: Supadata, requests_mock) -> N
         "details": "The requested item could not be found.",
     }
     requests_mock.get(
-        f"{client.base_url}/youtube/channel/videos?id={channel_id}",
+        f"{client.base_url}/youtube/channel/videos?id={channel_id}&type=all",
         status_code=404,
         json=mock_response,
     )
@@ -468,6 +502,10 @@ def test_youtube_playlist_videos(client: Supadata, requests_mock) -> None:
         "videoIds": [
             "zDNaUi2cjv4",
             "B1t4Fjlomi8",
+        ],
+        "shortIds": [
+            "short1",
+            "short2"
         ]
     }
     requests_mock.get(
@@ -476,10 +514,16 @@ def test_youtube_playlist_videos(client: Supadata, requests_mock) -> None:
     )
 
     playlist_videos = client.youtube.playlist.videos(playlist_id)
-    assert isinstance(playlist_videos, list)
-    assert len(playlist_videos) == len(mock_response["videoIds"])
-    for i in playlist_videos:
+    assert hasattr(playlist_videos, "video_ids")
+    assert hasattr(playlist_videos, "short_ids")
+    assert isinstance(playlist_videos.video_ids, list)
+    assert isinstance(playlist_videos.short_ids, list)
+    assert len(playlist_videos.video_ids) == len(mock_response["videoIds"])
+    assert len(playlist_videos.short_ids) == len(mock_response["shortIds"])
+    for i in playlist_videos.video_ids:
         assert i in mock_response["videoIds"]
+    for i in playlist_videos.short_ids:
+        assert i in mock_response["shortIds"]
 
 
 def test_youtube_playlist_videos_invalid_id(client: Supadata, requests_mock) -> None:


### PR DESCRIPTION




https://github.com/user-attachments/assets/7eeb50b5-a019-4bdc-b07d-59e25246b7d9


/claim #12
/closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved video retrieval functionality allows users to specify video types (e.g., all, video, or short) and control the number of results returned.
	- The output now clearly distinguishes between regular videos and YouTube Shorts for enhanced clarity.
  
- **Tests**
	- Expanded test coverage ensures that video retrieval handles both regular videos and Shorts correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->